### PR TITLE
Add cv.cm/v

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -182,6 +182,13 @@
   category: text-to-video-apis
   b2_integration: ""
   last_verified: 2026-04-21
+- name: cv.cm/v
+  url: https://cv.cm/v
+  docs_url: https://cv.cm/api
+  description: Queue-free Seedance 2.0 text-to-video and image-to-video, plus gpt-image-2/Seedream image generation, exposed through an open developer API.
+  category: text-to-video-apis
+  b2_integration: ""
+  last_verified: 2026-06-09
 
 # ---------------- Real-Time and Interactive Video ----------------
 


### PR DESCRIPTION
Adds **cv.cm/v** under `text-to-video-apis` (edited `entries.yaml` only, per the contribution rules).

cv.cm/v offers queue-free Seedance 2.0 text-to-video and image-to-video plus gpt-image-2/Seedream image generation, all callable through an open developer API (docs at https://cv.cm/api) — so it satisfies the "public API" eligibility requirement. One entry, valid YAML, URL resolves.