### PR TITLE
Add Avatar Video Workbench

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -945,6 +945,16 @@
   b2_integration: ""
   last_verified: 2026-05-04
 
+- name: Avatar Video Workbench
+  url: https://github.com/IaMarric/avatar-video-workbench
+  docs_url: https://github.com/IaMarric/avatar-video-workbench/tree/main/docs
+  description: Open-source CLI/control plane for reproducible avatar LoRA and image-to-video experiments, with Vertex job staging, LTX run metadata, sanitized reports, and publication safety scans.
+  category: sdks-and-developer-tooling
+  github: IaMarric/avatar-video-workbench
+  license: MIT
+  b2_integration: ""
+  last_verified: 2026-06-15
+
 # ---------------- Infrastructure and Deployment ----------------
 
 - name: Lambda Labs


### PR DESCRIPTION
## Summary

Adds Avatar Video Workbench as a developer tooling entry for reproducible avatar LoRA and image-to-video workflows.

I maintain the project. It is MIT-licensed and provides a Python CLI/control plane for Vertex CustomJob staging, LTX run metadata export, sanitized Vertex reports, dataset validation, and publication safety scans.

## Checklist

- Edited `entries.yaml` only.
- One entry in this PR.
- Public open-source install path: https://github.com/IaMarric/avatar-video-workbench
- Activity within the last 12 months: active release and CI on 2026-06-15.