### PR TITLE
Add iaVideo.pt (Portuguese AI video generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+- [iaVideo.pt](https://iavideo.pt) - Portuguese AI video generator (text-to-video & image-to-video) with 12+ models, narration & subtitles in European Portuguese.
+
 # Awesome Video Generation [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com) [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ![Abstract illustration of AI video generation systems](assets/readme-hero.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-- [iaVideo.pt](https://iavideo.pt) - Portuguese AI video generator (text-to-video & image-to-video) with 12+ models, narration & subtitles in European Portuguese.
-
 # Awesome Video Generation [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com) [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ![Abstract illustration of AI video generation systems](assets/readme-hero.png)
@@ -56,6 +54,7 @@ Maintained by [Backblaze](https://www.backblaze.com).
 - **[Vidu (Shengshu Technology)](https://www.shengshu.com/en/vidu)** – Now on Vidu Q3, the first long-form AI video model with native audio-video generation in a single output. Ranked
 - **[Wan 2.7 (Alibaba)](https://fal.ai/wan-2.7)** – Commercial successor to open-weight Wan 2.2. Native 1080p, 2–15s clips, first-and-last-frame control, up to 5 reference inputs, instruction-based video editing. Via DashScope and fal.ai at $0.10/sec. [Docs](https://help.aliyun.com/zh/model-studio/wanx-video-generation)
 - **[xAI Aurora / Grok Imagine](https://x.ai)** – Text-to-video and image-to-video using xAI's Aurora autoregressive MoE model. 6–15s clips at 720p with synchronized audio. [Docs](https://x.ai/news/grok-imagine-api)
+- **[iaVideo.pt](https://iavideo.pt)** - Portuguese AI video generator (text-to-video & image-to-video) with 12+ models, narration & subtitles in European Portuguese.
 
 ## Real-Time and Interactive Video
 


### PR DESCRIPTION
Adds iaVideo.pt under text-to-video / image-to-video services. A Portuguese AI video generator with 12+ models and European-Portuguese narration & subtitles.