### PR TITLE
Add YumCut short-video workflow

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -1195,3 +1195,17 @@
   license: Apache-2.0
   b2_integration: ""
   last_verified: 2026-05-04
+
+- name: YumCut
+  url: https://github.com/IgorShadurin/app.yumcut.com
+  docs_url: https://app.yumcut.com/api/user/v1/docs
+  description: Source-available, self-hosted short-video workflow that generates scripts, voiceovers, visuals, captions, and finished 9:16 videos. Includes a bearer-key API for project automation and media downloads.
+  category: templates-and-example-projects
+  github: IgorShadurin/app.yumcut.com
+  license: PolyForm-Noncommercial-1.0.0
+  tags:
+    - short-form-video
+    - self-hosted
+    - automation-api
+  b2_integration: ""
+  last_verified: 2026-07-09


### PR DESCRIPTION
## Summary

Add [YumCut](https://github.com/IgorShadurin/app.yumcut.com) to Templates and Example Projects.

YumCut is a source-available, self-hosted workflow for producing finished 9:16 videos from an idea. It includes script generation, voiceovers, visuals, captions, final rendering, and a scoped bearer-key API for project automation and media downloads.

## Inclusion requirements

- Public repository, hosted product, and [API documentation](https://app.yumcut.com/api/user/v1/docs)
- Active development within the last 12 months
- Self-hosted installation path and public automation API
- More than 800 GitHub stars

## Validation

- Edited `entries.yaml` only
- YAML parses successfully
- Repository, product, and documentation links return HTTP 200

## Affiliation

I am the creator and maintainer of YumCut.
