### PR TITLE
Add DaoXE multi-model multi-protocol video-capable gateway

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -167,6 +167,19 @@
   b2_integration: ""
   last_verified: 2026-04-17
 
+- name: DaoXE
+  url: https://daoxe.com
+  docs_url: https://github.com/seven7763/DaoXE-AI
+  description: "Multi-model multi-protocol AI API gateway exposing text, image, and video models through one account. Public catalog includes Sora, Veo, Kling, and Grok Imagine video IDs alongside image generation and chat protocols; not available in mainland China."
+  category: text-to-video-apis
+  github: seven7763/DaoXE-AI
+  sdks:
+    - {language: OpenAI SDK (Python/Node via base URL)}
+    - {language: cURL / Postman}
+  tags: [multi-model, multi-protocol, gateway]
+  b2_integration: ""
+  last_verified: 2026-07-13
+
 - name: Wan 2.7 (Alibaba)
   url: https://fal.ai/wan-2.7
   docs_url: https://help.aliyun.com/zh/model-studio/wanx-video-generation


### PR DESCRIPTION
## Summary
- Add **DaoXE** under **Text-to-Video APIs** (`entries.yaml` only).
- Multi-model multi-protocol AI API gateway; public catalog includes Sora / Veo / Kling / Grok Imagine video model IDs alongside image generation and chat protocols.
- Developer entrypoint and examples: https://github.com/seven7763/DaoXE-AI
- Not available in mainland China.

## Disclosure
I am affiliated with DaoXE.

## Notes
- Positioned similarly to other multi-model developer gateways (e.g. unified API access), not as a research paper.
- One entry only; maintainer may regenerate README from YAML.