### PR TITLE
Add OrkasVideoStudio developer tooling

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -838,6 +838,19 @@
   b2_integration: ""
   last_verified: 2026-03-01
 
+- name: OrkasVideoStudio
+  url: https://github.com/Orkas-AI/Orkas-VideoStudio
+  description: Local-first TypeScript CLI and MCP toolkit that lets coding agents compose, edit, generate, and assemble videos from editable plan.json timelines.
+  category: sdks-and-developer-tooling
+  github: Orkas-AI/Orkas-VideoStudio
+  license: MIT
+  tags:
+    - video-processing
+    - mcp
+    - cli
+  b2_integration: ""
+  last_verified: 2026-07-29
+
 - name: HuggingFace Diffusers
   url: https://github.com/huggingface/diffusers
   docs_url: https://huggingface.co/docs/diffusers


### PR DESCRIPTION
## Summary

Add one OrkasVideoStudio record to entries.yaml under SDKs and Developer Tooling.

## Why it fits

OrkasVideoStudio provides an open-source install path plus a TypeScript CLI and MCP interface for video composition, editing, provider-backed generation, and automatic assembly. It is MIT licensed and actively maintained.

## Validation

- Edited entries.yaml only, as required.
- Parsed the full YAML with PyYAML and verified the required fields, category, and description length.
- Canonical repository URL, license, and recent activity verified.
- git diff --check passes.