### PR TITLE
Add SandBase video model access

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -183,6 +183,17 @@
   b2_integration: ""
   last_verified: 2026-04-21
 
+- name: SandBase
+  url: https://github.com/sandbaseai/cli
+  docs_url: https://docs.sandbase.ai/models/
+  description: Unified CLI and MCP bridge for 2,000+ AI models and APIs, including video generation through Kling, MiniMax, Runway, and Luma with async job polling.
+  category: text-to-video-apis
+  github: sandbaseai/cli
+  license: Apache-2.0
+  tags: [multi-model, cli, mcp]
+  b2_integration: ""
+  last_verified: 2026-08-15
+
 # ---------------- Real-Time and Interactive Video ----------------
 
 - name: Decart (Lucy 2)

--- a/entries.yaml
+++ b/entries.yaml
@@ -186,7 +186,7 @@
 - name: SandBase
   url: https://github.com/sandbaseai/cli
   docs_url: https://docs.sandbase.ai/models/
-  description: Unified CLI and MCP bridge for 2,000+ AI models and APIs, including video generation through Kling, MiniMax, Runway, and Luma with async job polling.
+  description: Unified CLI and MCP bridge for 2,000+ AI models, including video generation through Kling, MiniMax, Runway, and Luma with async job polling.
   category: text-to-video-apis
   github: sandbaseai/cli
   license: Apache-2.0


### PR DESCRIPTION
## Summary

Adds one SandBase entry to `entries.yaml` under **Text-to-Video APIs**. The entry documents its unified CLI/MCP access to 2,000+ AI models, including Kling, MiniMax, Runway, and Luma video generation with async polling.

## Validation

- Edited only `entries.yaml`, as required.
- Confirmed there is no existing SandBase entry or PR.
- Public open-source install path: `@sandbaseai/cli` (Apache-2.0).
- Public developer documentation is linked.
- SandBase YAML block parses successfully and `git diff --check` passes.

Note: the upstream file contains pre-existing inline mappings with unquoted URL values that macOS system Ruby's YAML 1.1 parser rejects; this PR does not modify those lines.

## Disclosure

I am affiliated with SandBase. This contribution and PR text were prepared with AI assistance and reviewed before submission.