### PR TITLE
Add VideoScore2 evaluation benchmark

### DIFF
--- a/entries.yaml
+++ b/entries.yaml
@@ -1119,6 +1119,16 @@
   b2_integration: ""
   last_verified: 2026-06-01
 
+- name: VideoScore2
+  url: https://github.com/TIGER-AI-Lab/VideoScore2
+  docs_url: https://tiger-ai-lab.github.io/VideoScore2/
+  description: Open-source evaluator for generated videos across visual quality, text-video alignment, and physical/common-sense consistency, with a single-video inference script.
+  category: evaluation-and-observability
+  github: TIGER-AI-Lab/VideoScore2
+  license: MIT
+  b2_integration: ""
+  last_verified: 2026-08-17
+
 - name: Artificial Analysis Video Arena
   url: https://artificialanalysis.ai/video/arena
   docs_url: https://artificialanalysis.ai/video/leaderboard/text-to-video


### PR DESCRIPTION
## Summary

Add VideoScore2 to `evaluation-and-observability` in `entries.yaml`.

## Fit and source check

- The target contribution guide explicitly accepts evaluation benchmarks with runnable code or an open-source install path.
- The official repository provides a single-video inference script and dependency/setup instructions.
- The entry links the official repository and project documentation and uses the repository's MIT license.
- The current README plus open and closed issue/PR records were checked for `VideoScore2`, the paper title, arXiv `2509.22799`, and `TIGER-AI-Lab/VideoScore2`; no equivalent entry or discussion was found in the 2026-08-17 local recheck.

Disclosure: I am affiliated with the project and am happy to adjust the wording or placement.
